### PR TITLE
chore: add devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+    "image": "rust:latest",
+    "containerUser": "vscode",
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": "true",
+            "installOhMyZsh": "false",
+            "username": "vscode",
+            "userUid": "1000",
+            "userGid": "1000",
+            "upgradePackages": "true"
+        },
+    },
+    "runArgs": [
+        "--name=${localWorkspaceFolderBasename}_${localEnv:USER}"
+  ]
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy", "rust-analyzer", "llvm-tools-preview"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "stable"
-components = ["rustfmt", "clippy", "rust-analyzer", "llvm-tools-preview"]


### PR DESCRIPTION
We add a basic `devcontainer.json` that uses a Rust base docker image and creates a non-root user. This devcontainer will be a good base with which developers can use to build the project.